### PR TITLE
Update deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "basisjs-tools",
   "title": "Basis.js developer tools",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "homepage": "https://github.com/basisjs/basisjs-tools",
   "description": "Developer tools for basis.js framework",
   "author": "Roman Dvornov <rdvornov@gmail.com>",
@@ -23,24 +23,20 @@
     "basisjs-tools-config": "^1.0.0",
     "basisjs-tools-ast": "^1.0.0",
     "basisjs-tools-build": "basisjs/basisjs-tools-build",
-
     "clap": "1.0.8",
     "update-notifier": "0.5.0",
     "chalk": "1.1.0",
     "win-spawn": "2.0.0",
     "exit": "~0.1.2",
     "resolve": "1.1.6",
-    "minimatch": "2.0.10",
-
-    "socket.io": "1.3.6",
-    "socket.io-client": "1.3.6",
-    "http-proxy": "0.10.4",
+    "minimatch": "3.0.0",
+    "socket.io": "1.3.7",
+    "socket.io-client": "1.3.7",
+    "http-proxy": "1.12.0",
     "mime": "1.3.4"
   },
-  "devDependencies": {
-  },
-  "scripts": {
-  },
+  "devDependencies": {},
+  "scripts": {},
   "files": [
     "bin",
     "lib",


### PR DESCRIPTION
update socket-io to Node.js v4+ compatible version
I need this change to build https://github.com/lahmatiy/component-inspector under node 4.2.1

also update other outdated packages