### PR TITLE
updated socket.io version

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
     "exit": "0.1.2",
     "resolve": "1.1.7",
     "minimatch": "~3.0.2",
-    "socket.io": "~1.4.5",
-    "socket.io-client": "~1.4.5",
+    "socket.io": "~1.5.1",
+    "socket.io-client": "~1.5.1",
     "http-proxy": "0.10.4",
     "mime": "1.3.4"
   },


### PR DESCRIPTION
Now `basisjs-tools` is working on node.js 7
Old socket.io is not working on node.js 7